### PR TITLE
feat: homepage to use split layout with left and right content compon…

### DIFF
--- a/client/app/(routes)/page.tsx
+++ b/client/app/(routes)/page.tsx
@@ -1,22 +1,22 @@
 "use client";
 
 import { ReactElement } from "react";
-import HelloWorld from "../_components/HelloWorld";
-import TelegramUser from "../_components/TelegramUser";
-import { TwitterLogin } from "../_components/TwitterLogin";
-import { DiscordLogin } from "../_components/DiscordLogin";
-import { GithubLogin } from "../_components/GithubLogin";
+import MainContent from "../_components/MainContent";
+// import HelloWorld from "../_components/HelloWorld";
+// import TelegramUser from "../_components/TelegramUser";
+// import { TwitterLogin } from "../_components/TwitterLogin";
+// import { DiscordLogin } from "../_components/DiscordLogin";
+// import { GithubLogin } from "../_components/GithubLogin";
 
 export default function Home(): ReactElement {
   return (
-    <main className="min-h-screen w-full flex items-center justify-center p-4">
-      <div className="w-full max-w-4xl mx-auto">
-        <HelloWorld />
-        <TelegramUser />
-        <TwitterLogin />
-        <DiscordLogin />
-        <GithubLogin />
-      </div>
+    <main className="min-h-screen w-full p-4">
+      <MainContent />
+      {/* <HelloWorld />
+      <TelegramUser />
+      <TwitterLogin />
+      <DiscordLogin />
+      <GithubLogin /> */}
     </main>
   );
 }

--- a/client/app/_components/LeftContent.tsx
+++ b/client/app/_components/LeftContent.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { ReactElement } from "react";
+
+export default function LeftContent(): ReactElement {
+  return (
+    <div className="w-1/2 border-r border-gray-300 p-8">
+      LeftContent
+    </div>
+  )
+}

--- a/client/app/_components/MainContent.tsx
+++ b/client/app/_components/MainContent.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import { ReactElement } from "react";
+import { cn } from "@/lib/utils";
+import LeftContent from "./LeftContent";
+import RightContent from "./RightContent";
+
+// レイアウト全体を左右に分割するコンポーネント
+const SplitLayout = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex min-h-screen", className)}
+      {...props}
+    />
+  )
+);
+SplitLayout.displayName = "SplitLayout";
+
+export default function MainContent(): ReactElement {
+  return (
+    <SplitLayout>
+      <LeftContent />
+      <RightContent />
+    </SplitLayout>
+  );
+}

--- a/client/app/_components/RightContent.tsx
+++ b/client/app/_components/RightContent.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { ReactElement } from "react";
+
+export default function RightContent(): ReactElement {
+  return (
+    <div className="w-1/2 p-8">
+      RightContent
+    </div>
+  )
+}


### PR DESCRIPTION
今後のイシュー分業を楽にするために、クライアントのメインページの表示を変更してみました！
![image](https://github.com/user-attachments/assets/ebf6effc-ca08-43ef-b449-165a6eefdf27)

- 表示幅最大化
- 左右のコンポーネントに分離