### PR TITLE
fix: llm js function generation

### DIFF
--- a/client/app/api/chat/route.ts
+++ b/client/app/api/chat/route.ts
@@ -2,7 +2,7 @@
 import streamAll from './streamAll';
 
 // Allow streaming responses up to 30 seconds
-export const maxDuration = 30;
+// export const maxDuration = 30;
 
 
 

--- a/client/prompts/jsCodePrompts.tsx
+++ b/client/prompts/jsCodePrompts.tsx
@@ -195,7 +195,7 @@ interface Transaction {
 ### グラフデータ
 
 \`\`\`typescript
-interface GrphNode {
+interface GraphNode {
   id: number;
   label: string;
   title: string;
@@ -254,15 +254,15 @@ declare function update(
    \`\`\`javascript
    function update(transactions, nodeMap, edgeMap) {
      transactions.forEach((tx) => {
-       const senderNode = nodeMap.get(tx.sender);
-       const receiverNode = nodeMap.get(tx.receiver);
+       const senderNode = nodeMap[tx.sender];
+       const receiverNode = nodeMap[tx.receiver];
    
        // nodeのsizeの更新
        senderNode.size += 1;
        receiverNode.size += 1;
    
        const edgeKey = \`${"$"}{senderNode.id}-${"$"}{receiverNode.id}\`;
-       const edge = edgeMap.get(edgeKey);
+       const edge = edgeMap[edgeKey];
    
        // edgeのwidthの更新
        edge.width += 1;


### PR DESCRIPTION
LLMによる評価グラフ作成のためのJS関数生成に関する修正です
- グラフ用JS関数生成のプロンプト内、オブジェクト周りを微修正
- 全ての種類のチャットでグラフ用JS関数ツールの呼び出しを強制
  - 分配率まわりはチャット外のUIで行うことになったため、ひとまずの措置
  - チャット欄にスペース一文字を打って、エンターを押すだけでプロンプトをはいてくれるようになりました